### PR TITLE
Anchor block

### DIFF
--- a/franklin/blocks/anchor-section/anchor-section.css
+++ b/franklin/blocks/anchor-section/anchor-section.css
@@ -1,0 +1,11 @@
+main .anchor-section {
+  display: none;
+}
+
+main div.section.anchor-section-toggle--active {
+  display: block;
+}
+
+main div.section.anchor-section-toggle--hidden {
+  display: none;
+}

--- a/franklin/blocks/anchor-section/anchor-section.js
+++ b/franklin/blocks/anchor-section/anchor-section.js
@@ -1,0 +1,22 @@
+import { NAVBAR_HEIGHT } from '../../scripts/scripts/utils.js';
+
+export default async function anchorSection(block) {
+  const anchor = block.textContent.trim();
+  if (!anchor[0] === '#') return;
+  const section = block.closest('main > .section');
+  block.remove();
+  section.setAttribute('data-anchor-section', anchor);
+  section.setAttribute('id', anchor.substring(1));
+  Array.from(document.querySelectorAll(`a[href$="${anchor}"]`)).forEach((a) => {
+    a.addEventListener('click', (e) => {
+      e.preventDefault();
+      Array.from(document.querySelectorAll('.section[data-anchor-section]')).forEach((section) => {
+        section.classList.add('anchor-section-toggle--hidden');
+        section.classList.remove('anchor-section-toggle--active');
+      });
+      section.classList.add('anchor-section-toggle--active');
+      section.classList.remove('anchor-section-toggle--hidden');
+      window.scroll({ top: section.offsetTop - NAVBAR_HEIGHT, left: 0, behavior: 'smooth', });
+    });
+  });
+}

--- a/franklin/scripts/scripts/utils.js
+++ b/franklin/scripts/scripts/utils.js
@@ -38,13 +38,9 @@ export const [setLibs, getLibs] = (() => {
   ];
 })();
 
-/* eslint-disable no-restricted-syntax */
-export function createTag(name, attrs) {
-  const el = document.createElement(name);
-  if (typeof attrs === 'object') {
-    for (const [key, value] of Object.entries(attrs)) {
-      el.setAttribute(key, value);
-    }
-  }
-  return el;
-}
+const LIBS = 'https://milo.adobe.com/libs';
+const miloLibs = setLibs(LIBS);
+export const { createTag, getConfig } = await import(`${miloLibs}/utils/utils.js`);
+export const { replaceKey } = await import(`${miloLibs}/features/placeholders.js`);
+export const { decorateBlockAnalytics, decorateLinkAnalytics } = await import(`${miloLibs}/martech/attributes.js`);
+export const NAVBAR_HEIGHT = 97


### PR DESCRIPTION
This PR is to move over anchor block from the old stock repo for the migration of the Artist Hub pages.
This is to ensure that this block doesn't fail to load and for future use.

**Test URLs:**
Before: https://ah-staging--adobestock--wbstry.hlx.page/pages/artisthub/learn/courses
After: 

The goal is to provide a similar experience to the current production website which can be viewed here:
https://main--stock--adobecom.hlx.page/pages/artisthub/learn/courses